### PR TITLE
✨ App.vue에 특정페이지(Login, Sign) 헤더 푸터 제거(afterEach 훅 사용)

### DIFF
--- a/cafefront/around_cafe/src/App.vue
+++ b/cafefront/around_cafe/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app>
-    <TheHeader />
+    <TheHeader v-if="visible" />
     <v-main>
       <v-container>
         <v-row>
@@ -10,17 +10,33 @@
         </v-row>
       </v-container>
     </v-main>
-    <TheFooter />
+    <TheFooter v-if="visible" />
   </v-app>
 </template>
 
 <script>
 import TheFooter from "@/components/Layouts/TheFooter.vue"
 import TheHeader from "@/components/Layouts/TheHeader.vue"
-
+import router from "./router"
 export default {
   components: { TheHeader, TheFooter },
   name: "App",
+  data() {
+    return {
+      visible: false,
+    }
+  },
+  /* eslint-disable */
+  created() {
+    let visible = false
+    router.afterEach((to, from) => {
+      if ((visible = to.path === "/sign") || (visible = to.path === "/login")) {
+        this.visible = false
+      } else {
+        this.visible = true
+      }
+    })
+  },
 }
 </script>
 <style lang="scss">

--- a/cafefront/around_cafe/src/assets/scss/components/account/_login.scss
+++ b/cafefront/around_cafe/src/assets/scss/components/account/_login.scss
@@ -37,7 +37,6 @@
     text-align: center;
     margin: 40px 0;
     &-group {
-      margin-bottom: 32px;
       @include flexbox(center);
       .v-btn {
         margin-right: 32px;

--- a/cafefront/around_cafe/src/assets/scss/components/account/_sign.scss
+++ b/cafefront/around_cafe/src/assets/scss/components/account/_sign.scss
@@ -1,6 +1,6 @@
 .sign {
   padding: 40px 40px 0 40px;
-
+  overflow-y: hidden;
   .account-input .form-input {
     margin-bottom: 8px;
   }

--- a/cafefront/around_cafe/src/assets/scss/vendors/_reset.scss
+++ b/cafefront/around_cafe/src/assets/scss/vendors/_reset.scss
@@ -14,7 +14,7 @@ html {
 body {
   font-family: $font-main;
   color: $primary;
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 h1 {

--- a/cafefront/around_cafe/src/components/Account/AccountLogin.vue
+++ b/cafefront/around_cafe/src/components/Account/AccountLogin.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="login">
     <header class="login-header">
-      <h2>Arround Cafe</h2>
+      <router-link :to="{ name: 'MainPage' }">
+        <h2>Arround Cafe</h2>
+      </router-link>
     </header>
 
     <section class="login-section">

--- a/cafefront/around_cafe/src/router/index.js
+++ b/cafefront/around_cafe/src/router/index.js
@@ -43,6 +43,9 @@ const routes = [
     path: "/",
     redirect: "/main",
     component: () => import("@/views/MainPage.vue"),
+    meta: {
+      title: "Around Cafe",
+    },
   },
   {
     path: "/main",
@@ -148,11 +151,11 @@ const routes = [
     path: "/cafeQnAPage",
     name: "CafeQnAPage",
     components: {
-      default :CafeQnAPage
+      default: CafeQnAPage,
     },
-    props : {
-      default: true
-    }
+    props: {
+      default: true,
+    },
   },
 
   {
@@ -191,6 +194,16 @@ const router = new VueRouter({
   mode: "history",
   base: process.env.BASE_URL,
   routes,
+})
+/* eslint-disable */
+// 홈페이지 타이틀 변경, 현재 우리가 디렉토리명인 around_cafe로 나오고 있어서
+// Around Cafe로 변경하는 라우터
+router.afterEach((to, from) => {
+  const title = to.meta.title === undefined ? "Around Cafe" : to.meta.title
+
+  Vue.nextTick(() => {
+    document.title = title
+  })
 })
 
 export default router


### PR DESCRIPTION
1. App.vue
 - 라우터네비게이션가드 사용하여 /Login, /Sign 경로에 Header, Footer 보이지 않게 함

2. Login에 scorll이 하나 더 생겨서 전역 body에 overflow: hidden으로 제거(전역으로 먹여도 괜찮은가 모르겠음)

3. Sign 필요없는 marginbottom 없앰 

4. router
 - 홈페이지 title이 디렉토리명인 around_cafe로 나와 훅 사용하여 title : Around Cafe로 변경